### PR TITLE
Removal of printed tokens in consul-template

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -x
+set -v
 set -e
 export VAULT_ADDR=https://vault.infra
 export VAULT_SKIP_VERIFY=true


### PR DESCRIPTION
## Motivation:
Currently all builds are exposing tokens that can access vault with full access and also EKS tokens that can be damaging. This is needed to stop builds from exposing tokens and secrets. 

Currently one can do a `kubectl logs <POD_ID> -c consul-template` and it'll throw all these tokens.

## Change:
Replaces `set -x` that prints statements with their arguments, to `set -v` that just prints the line that is going to be executed.